### PR TITLE
Add CUA hotkeys for manipulating windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,19 @@ To show a dialog is exactly the same as Avalonia, you instantiate a ManagedWindo
 ```
 
 To close a dialog you call **Close(result)**;
+
+# HotKeys
+The window manager supports hotkeys for common actions like closing a window, minimizing, maximizing, etc.
+
+|Hotkey | Action |
+|--------|--------|
+|Ctrl+F4 | Close the current window |
+|Ctrl+Tab| Activate the next window |
+|Ctrl+Shift+Tab | Activate the previous window |
+|Alt+-| Show System menu (Restore/Move/Size/Maximize/Minimize/Close)|
+|F6| Activate the next window |
+|Shift+F6| Activate the previous window |
+
+> NOTE: On windows consoles Ctrl+Tab and Ctrl+Shift+Tab are handled by the console window, so F6 and Shift+F6 should be used instead.
+
+

--- a/source/Demo/Demo.Console/App.axaml
+++ b/source/Demo/Demo.Console/App.axaml
@@ -8,7 +8,7 @@
   </Application.Resources>
 
   <Application.Styles>
-    <console:MaterialTheme />
+    <console:FluentTheme />
 
     <wm:WindowManagerTheme />
   </Application.Styles>

--- a/source/Demo/Demo/Views/MainView.axaml
+++ b/source/Demo/Demo/Views/MainView.axaml
@@ -38,7 +38,7 @@
     
     <StackPanel Orientation="Horizontal" >
       <Button HorizontalAlignment="Left" Click="OnClick" Content="Increment"/>
-      <TextBlock Text="Counter:" />
+      <TextBlock Text="Counter:"  VerticalAlignment="Center" />
       <TextBlock Text="{Binding Counter}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
     </StackPanel>
   </StackPanel>

--- a/source/Demo/Demo/Views/MainView.axaml
+++ b/source/Demo/Demo/Views/MainView.axaml
@@ -6,7 +6,7 @@
                        xmlns:vm="using:Demo.ViewModels"
                        x:Class="Demo.Views.MainView"
                        x:DataType="vm:MainViewModel">
-  <StackPanel Background="AliceBlue" Spacing="1">
+  <StackPanel Spacing="1">
     <StackPanel Orientation="Horizontal" Spacing="1">
       <Label>SizeToContent for new Window</Label>
       <ComboBox Name="SizeToContentCombo" SelectedIndex="3">

--- a/source/Demo/Demo/Views/MyDialog.axaml
+++ b/source/Demo/Demo/Views/MyDialog.axaml
@@ -8,6 +8,7 @@
         x:Class="Demo.MyDialog"
         x:DataType="local:MyDialogViewModel"
         ShowActivated="True"
+                  CanResize="False"
         Title="{Binding Title}">
   <StackPanel Spacing="1" Margin="1">
     <StackPanel Orientation="Horizontal"  Spacing="1">

--- a/source/Iciclecreek.Avalonia.WindowManager/Iciclecreek.Avalonia.WindowManager.csproj
+++ b/source/Iciclecreek.Avalonia.WindowManager/Iciclecreek.Avalonia.WindowManager.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.6</Version>
-    <AssemblyVersion>2.0.6.0</AssemblyVersion>
+    <Version>2.1.0</Version>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
     <Description>This library implements a window manager for Avalonia with windows defined using Avalonia instead of native windows.</Description>
     <Company>Iciclecreek</Company>
     <Authors>Tom Laird-McConnell</Authors>

--- a/source/Iciclecreek.Avalonia.WindowManager/Iciclecreek.Avalonia.WindowManager.csproj
+++ b/source/Iciclecreek.Avalonia.WindowManager/Iciclecreek.Avalonia.WindowManager.csproj
@@ -36,9 +36,9 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.2.5" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.2.5" />
     <PackageReference Include="Consolonia.Controls" Version="11.2.5-beta.*" />
     <PackageReference Include="IconPacks.Avalonia.Codicons" Version="1.0.0" />
-    <PackageReference Include="ReactiveUI" Version="20.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Iciclecreek.Avalonia.WindowManager/Iciclecreek.Avalonia.WindowManager.csproj
+++ b/source/Iciclecreek.Avalonia.WindowManager/Iciclecreek.Avalonia.WindowManager.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.5</Version>
-    <AssemblyVersion>2.0.5.0</AssemblyVersion>
+    <Version>2.0.6</Version>
+    <AssemblyVersion>2.0.6.0</AssemblyVersion>
     <Description>This library implements a window manager for Avalonia with windows defined using Avalonia instead of native windows.</Description>
     <Company>Iciclecreek</Company>
     <Authors>Tom Laird-McConnell</Authors>

--- a/source/Iciclecreek.Avalonia.WindowManager/Iciclecreek.Avalonia.WindowManager.csproj
+++ b/source/Iciclecreek.Avalonia.WindowManager/Iciclecreek.Avalonia.WindowManager.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="Avalonia" Version="11.2.5" />
     <PackageReference Include="Consolonia.Controls" Version="11.2.5-beta.*" />
     <PackageReference Include="IconPacks.Avalonia.Codicons" Version="1.0.0" />
+    <PackageReference Include="ReactiveUI" Version="20.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
@@ -53,7 +53,7 @@
 
               <!--Title Bar-->
               <Grid Name="PART_TitleBar"
-                    ColumnDefinitions="Auto * Auto"
+                    ColumnDefinitions="Auto Auto * Auto"
                     Background="{DynamicResource ManagedWindow_TitleBarBackgroundBrush}">
                 <Grid.Styles>
                   <Style Selector="Button">
@@ -61,14 +61,27 @@
                   </Style>
                 </Grid.Styles>
 
+                <!--system button-->
+                <Button Name="PART_SystemButton"
+                        IsTabStop="True"
+                        Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
+                  <console:OnPlatform Console="≡">
+                    <console:OnPlatform.Default>
+                      <iconPacks:Codicons Kind="Menu"
+                                          Width="{StaticResource ManagedWindow_SystemIconSize}"
+                                          Height="{StaticResource ManagedWindow_SystemIconSize}"/>
+                    </console:OnPlatform.Default>
+                  </console:OnPlatform>
+                </Button>
+
                 <!-- Icon -->
-                <ContentPresenter Grid.Column="0"
+                <ContentPresenter Grid.Column="1"
                                   VerticalAlignment="Center"
                                   HorizontalAlignment="Center"
                                   Content="{TemplateBinding Icon}" />
                 <!-- Title -->
                 <TextBlock Name="PART_Title"
-                           Grid.Column="1"
+                           Grid.Column="2"
                            Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}"
                            VerticalAlignment="Center"
                            FontFamily="{TemplateBinding FontFamily}"
@@ -78,7 +91,7 @@
                            Text="{TemplateBinding Title}"/>
 
                 <!-- System Decorations (aka buttons)-->
-                <StackPanel Grid.Column="2"
+                <StackPanel Grid.Column="3"
                             Orientation="Horizontal"
                             VerticalAlignment="Center"
                             HorizontalAlignment="Right">

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
@@ -2,7 +2,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:iconPacks="https://github.com/MahApps/IconPacks.Avalonia"
         xmlns:console="https://github.com/jinek/consolonia"
-        xmlns:wm="using:Iciclecreek.Avalonia.WindowManager">
+        xmlns:wm="using:Iciclecreek.Avalonia.WindowManager"
+        x:DataType="wm:ManagedWindow">
 
   <!--console extra resources-->
   <BoxShadows x:Key="NullBoxShadows" >none</BoxShadows>
@@ -15,6 +16,55 @@
   <console:LineBrush x:Key="ManagedWindow_Active_EdgeLineBrush"
                   Brush="{DynamicResource ManagedWindow_Active_BorderBrush}"
                   LineStyle="Edge"/>
+
+  <DataTemplate x:Key="MinimizeIcon">
+    <ContentControl>
+      <console:OnPlatform Console="🗕" >
+        <console:OnPlatform.Default>
+          <iconPacks:Codicons Kind="ChromeMinimize"
+                              Width="{StaticResource ManagedWindow_SystemIconSize}"
+                              Height="{StaticResource ManagedWindow_SystemIconSize}"/>
+        </console:OnPlatform.Default>
+      </console:OnPlatform>
+    </ContentControl>
+  </DataTemplate>
+
+  <DataTemplate x:Key="MaximizeIcon">
+    <ContentControl>
+      <console:OnPlatform Console="🗖">
+        <console:OnPlatform.Default>
+          <iconPacks:Codicons Kind="ChromeMaximize"
+                          Width="{StaticResource ManagedWindow_SystemIconSize}"
+                          Height="{StaticResource ManagedWindow_SystemIconSize}"/>
+        </console:OnPlatform.Default>
+      </console:OnPlatform>
+    </ContentControl>
+  </DataTemplate>
+
+  <DataTemplate x:Key="RestoreIcon">
+    <ContentControl>
+      <console:OnPlatform Console="🗗">
+        <console:OnPlatform.Default>
+          <iconPacks:Codicons Kind="ChromeRestore"
+                          Width="{StaticResource ManagedWindow_SystemIconSize}"
+                          Height="{StaticResource ManagedWindow_SystemIconSize}"/>
+        </console:OnPlatform.Default>
+      </console:OnPlatform>
+    </ContentControl>
+  </DataTemplate>
+
+  <DataTemplate x:Key="CloseIcon">
+    <ContentControl>
+      <console:OnPlatform Console="🗙">
+        <console:OnPlatform.Default>
+          <iconPacks:Codicons Kind="ChromeClose"
+                          Width="{StaticResource ManagedWindow_SystemIconSize}"
+                          Height="{StaticResource ManagedWindow_SystemIconSize}"/>
+        </console:OnPlatform.Default>
+      </console:OnPlatform>
+    </ContentControl>
+  </DataTemplate>
+
   <!--console resources-->
 
   <ControlTheme x:Key="{x:Type wm:ManagedWindow}"
@@ -62,17 +112,42 @@
                 </Grid.Styles>
 
                 <!--system button-->
-                <Button Name="PART_SystemButton"
+                <Menu Name="PART_SystemMenu"
                         IsTabStop="True"
                         Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
-                  <console:OnPlatform Console="≡">
-                    <console:OnPlatform.Default>
-                      <iconPacks:Codicons Kind="Menu"
-                                          Width="{StaticResource ManagedWindow_SystemIconSize}"
-                                          Height="{StaticResource ManagedWindow_SystemIconSize}"/>
-                    </console:OnPlatform.Default>
-                  </console:OnPlatform>
-                </Button>
+                  <MenuItem>
+                    <MenuItem.Header>
+                      <console:OnPlatform Console="☰">
+                        <console:OnPlatform.Default>
+                          <iconPacks:Codicons Kind="Menu"
+                                              Width="{StaticResource ManagedWindow_SystemIconSize}"
+                                              Height="{StaticResource ManagedWindow_SystemIconSize}"/>
+                        </console:OnPlatform.Default>
+                      </console:OnPlatform>
+                    </MenuItem.Header>
+
+                    <MenuItem Header="_Restore" >
+                      <MenuItem.Icon>
+                        <ContentControl ContentTemplate="{StaticResource RestoreIcon}" />
+                      </MenuItem.Icon>
+                    </MenuItem>
+                    <MenuItem Header="Mi_nimize">
+                      <MenuItem.Icon>
+                        <ContentControl ContentTemplate="{StaticResource MinimizeIcon}" />
+                      </MenuItem.Icon>
+                    </MenuItem>
+                    <MenuItem Header="Ma_ximize">
+                      <MenuItem.Icon>
+                        <ContentControl ContentTemplate="{StaticResource MaximizeIcon}" />
+                      </MenuItem.Icon>
+                    </MenuItem>
+                    <MenuItem Header="_Close">
+                      <MenuItem.Icon>
+                        <ContentControl ContentTemplate="{StaticResource CloseIcon}" />
+                      </MenuItem.Icon>
+                    </MenuItem>
+                  </MenuItem>
+                </Menu>
 
                 <!-- Icon -->
                 <ContentPresenter Grid.Column="1"
@@ -100,51 +175,22 @@
                   </StackPanel.Spacing>
                   <Button Name="PART_MinimizeButton"
                           IsTabStop="True"
-                          Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
-                    <console:OnPlatform Console="🗕">
-                      <console:OnPlatform.Default>
-                        <iconPacks:Codicons Kind="ChromeMinimize"
-                                            Width="{StaticResource ManagedWindow_SystemIconSize}"
-                                            Height="{StaticResource ManagedWindow_SystemIconSize}"/>
-                      </console:OnPlatform.Default>
-                    </console:OnPlatform>
-                  </Button>
+                          Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}"
+                          ContentTemplate="{StaticResource MinimizeIcon}" />
                   <Button Name="PART_MaximizeButton"
                           IsVisible="False"
                           IsTabStop="True"
-                          Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
-
-                    <console:OnPlatform Console="🗖">
-                      <console:OnPlatform.Default>
-                        <iconPacks:Codicons Kind="ChromeMaximize"
-                                        Width="{StaticResource ManagedWindow_SystemIconSize}"
-                                        Height="{StaticResource ManagedWindow_SystemIconSize}"/>
-                      </console:OnPlatform.Default>
-                    </console:OnPlatform>
-                  </Button>
+                          Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}"
+                          ContentTemplate="{StaticResource MaximizeIcon}" />
                   <Button Name="PART_RestoreButton"
                           IsVisible="False"
                           IsTabStop="True"
-                          Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
-                    <console:OnPlatform Console="🗗">
-                      <console:OnPlatform.Default>
-                        <iconPacks:Codicons Kind="ChromeRestore"
-                                        Width="{StaticResource ManagedWindow_SystemIconSize}"
-                                        Height="{StaticResource ManagedWindow_SystemIconSize}"/>
-                      </console:OnPlatform.Default>
-                    </console:OnPlatform>
-                  </Button>
+                          Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}"
+                          ContentTemplate="{StaticResource RestoreIcon}" />
                   <Button Name="PART_CloseButton"
                           IsTabStop="True"
-                          Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
-                    <console:OnPlatform Console="🗙">
-                      <console:OnPlatform.Default>
-                        <iconPacks:Codicons Kind="ChromeClose"
-                                        Width="{StaticResource ManagedWindow_SystemIconSize}"
-                                        Height="{StaticResource ManagedWindow_SystemIconSize}"/>
-                      </console:OnPlatform.Default>
-                    </console:OnPlatform>
-                  </Button>
+                          Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}"
+                          ContentTemplate="{StaticResource CloseIcon}" />
                 </StackPanel>
               </Grid>
 
@@ -152,7 +198,7 @@
               <ContentPresenter Grid.Row="1"
                                 Name="PART_ContentPresenter"
                                 ClipToBounds="True"
-                                KeyboardNavigation.TabNavigation="Continue"                                
+                                KeyboardNavigation.TabNavigation="Continue"
                                 Margin="{TemplateBinding Margin}"
                                 Padding="{TemplateBinding Padding}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}"
@@ -238,14 +284,14 @@
 
     <!--no border -->
     <Style Selector="^:noborder /template/ Border#PART_WindowBorder">
-      <Setter Property="BorderThickness" Value="{StaticResource NoThickness}}"/>
+      <Setter Property="BorderThickness" Value="{StaticResource NoThickness}"/>
     </Style>
 
     <!--no titlebar -->
     <Style Selector="^:notitle /template/ Grid#PART_TitleBar">
       <Setter Property="IsVisible" Value="False"/>
     </Style>
-    
+
     <!-- dialog state styles -->
 
     <!-- window is a dialog -->

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
@@ -100,6 +100,34 @@
                   CornerRadius="{TemplateBinding CornerRadius}">
             <Grid RowDefinitions="Auto *"
                   Background="{TemplateBinding Background}">
+              <Grid.KeyBindings>
+                <KeyBinding Gesture="Ctrl+F4"
+                            Command="{Binding $parent[wm:ManagedWindow].CloseCommand}" />
+
+                <KeyBinding Gesture="Ctrl+W"
+                            Command="{Binding $parent[wm:ManagedWindow].CloseCommand}" />
+
+                <KeyBinding Gesture="Ctrl+R"
+                            Command="{Binding $parent[wm:ManagedWindow].RestoreCommand}" />
+
+                <KeyBinding Gesture="Ctrl+M"
+                            Command="{Binding $parent[wm:ManagedWindow].MinimizeCommand}" />
+
+                <KeyBinding Gesture="Ctrl+Shift+M"
+                            Command="{Binding $parent[wm:ManagedWindow].MaximizeCommand}" />
+
+                <!--<KeyBinding Gesture="Ctrl+Tab"
+                            Command="{Binding $parent[wm:ManagedWindow].NextWindowCommand}" />
+
+                <KeyBinding Gesture="Ctrl+Alt+Tab"
+                            Command="{Binding $parent[wm:ManagedWindow].NextWindowCommand}" />
+
+                <KeyBinding Gesture="Ctrl+Shift+Tab"
+                            Command="{Binding $parent[wm:ManagedWindow].PreviousWindowCommand}" />
+
+                <KeyBinding Gesture="Ctrl+Alt+Shift+Tab"
+                            Command="{Binding $parent[wm:ManagedWindow].PreviousWindowCommand}" />-->
+              </Grid.KeyBindings>
 
               <!--Title Bar-->
               <Grid Name="PART_TitleBar"

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
@@ -126,22 +126,22 @@
                       </console:OnPlatform>
                     </MenuItem.Header>
 
-                    <MenuItem Header="_Restore" >
+                    <MenuItem Header="_Restore" Command="{Binding $parent[wm:ManagedWindow].RestoreCommand}" >
                       <MenuItem.Icon>
                         <ContentControl ContentTemplate="{StaticResource RestoreIcon}" />
                       </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="Mi_nimize">
+                    <MenuItem Header="Mi_nimize" Command="{Binding $parent[wm:ManagedWindow].MinimizeCommand}" >
                       <MenuItem.Icon>
                         <ContentControl ContentTemplate="{StaticResource MinimizeIcon}" />
                       </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="Ma_ximize">
+                    <MenuItem Header="Ma_ximize" Command="{Binding $parent[wm:ManagedWindow].MaximizeCommand}" >
                       <MenuItem.Icon>
                         <ContentControl ContentTemplate="{StaticResource MaximizeIcon}" />
                       </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="_Close">
+                    <MenuItem Header="_Close" Command="{Binding $parent[wm:ManagedWindow].CloseCommand}" >
                       <MenuItem.Icon>
                         <ContentControl ContentTemplate="{StaticResource CloseIcon}" />
                       </MenuItem.Icon>

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
@@ -101,32 +101,10 @@
             <Grid RowDefinitions="Auto *"
                   Background="{TemplateBinding Background}">
               <Grid.KeyBindings>
+                <KeyBinding Gesture="Alt+-"
+                              Command="{Binding $parent[wm:ManagedWindow].ShowSystemMenuCommand}" />
                 <KeyBinding Gesture="Ctrl+F4"
                             Command="{Binding $parent[wm:ManagedWindow].CloseCommand}" />
-
-                <KeyBinding Gesture="Ctrl+W"
-                            Command="{Binding $parent[wm:ManagedWindow].CloseCommand}" />
-
-                <KeyBinding Gesture="Ctrl+R"
-                            Command="{Binding $parent[wm:ManagedWindow].RestoreCommand}" />
-
-                <KeyBinding Gesture="Ctrl+M"
-                            Command="{Binding $parent[wm:ManagedWindow].MinimizeCommand}" />
-
-                <KeyBinding Gesture="Ctrl+Shift+M"
-                            Command="{Binding $parent[wm:ManagedWindow].MaximizeCommand}" />
-
-                <!--<KeyBinding Gesture="Ctrl+Tab"
-                            Command="{Binding $parent[wm:ManagedWindow].NextWindowCommand}" />
-
-                <KeyBinding Gesture="Ctrl+Alt+Tab"
-                            Command="{Binding $parent[wm:ManagedWindow].NextWindowCommand}" />
-
-                <KeyBinding Gesture="Ctrl+Shift+Tab"
-                            Command="{Binding $parent[wm:ManagedWindow].PreviousWindowCommand}" />
-
-                <KeyBinding Gesture="Ctrl+Alt+Shift+Tab"
-                            Command="{Binding $parent[wm:ManagedWindow].PreviousWindowCommand}" />-->
               </Grid.KeyBindings>
 
               <!--Title Bar-->
@@ -141,9 +119,9 @@
 
                 <!--system button-->
                 <Menu Name="PART_SystemMenu"
-                        IsTabStop="True"
+                        IsTabStop="True" 
                         Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
-                  <MenuItem>
+                  <MenuItem Name="PART_SystemMenuItem">
                     <MenuItem.Header>
                       <console:OnPlatform Console="☰">
                         <console:OnPlatform.Default>

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
@@ -119,7 +119,7 @@
 
                 <!--system button-->
                 <Menu Name="PART_SystemMenu"
-                        IsTabStop="True" 
+                        IsTabStop="True"
                         Foreground="{DynamicResource ManagedWindow_TitleBarForegroundBrush}">
                   <MenuItem Name="PART_SystemMenuItem">
                     <MenuItem.Header>
@@ -132,7 +132,7 @@
                       </console:OnPlatform>
                     </MenuItem.Header>
 
-                    <MenuItem Header="_Restore" Command="{Binding $parent[wm:ManagedWindow].RestoreCommand}" >
+                    <MenuItem Header="_Restore" Command="{Binding $parent[wm:ManagedWindow].RestoreCommand}">
                       <MenuItem.Icon>
                         <ContentControl ContentTemplate="{StaticResource RestoreIcon}" />
                       </MenuItem.Icon>

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
@@ -171,7 +171,7 @@
                             VerticalAlignment="Center"
                             HorizontalAlignment="Right">
                   <StackPanel.Spacing>
-                    <console:OnPlatformExtension x:TypeArguments="x:Double" Default="8" Console="-1" />
+                    <console:OnPlatformExtension x:TypeArguments="x:Double" Default="8" Console="0" />
                   </StackPanel.Spacing>
                   <Button Name="PART_MinimizeButton"
                           IsTabStop="True"

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml
@@ -102,7 +102,7 @@
                   Background="{TemplateBinding Background}">
               <Grid.KeyBindings>
                 <KeyBinding Gesture="Alt+-"
-                              Command="{Binding $parent[wm:ManagedWindow].ShowSystemMenuCommand}" />
+                            Command="{Binding $parent[wm:ManagedWindow].ShowSystemMenuCommand}" />
                 <KeyBinding Gesture="Ctrl+F4"
                             Command="{Binding $parent[wm:ManagedWindow].CloseCommand}" />
               </Grid.KeyBindings>
@@ -137,6 +137,8 @@
                         <ContentControl ContentTemplate="{StaticResource RestoreIcon}" />
                       </MenuItem.Icon>
                     </MenuItem>
+                    <MenuItem Header="_Move" Command="{Binding $parent[wm:ManagedWindow].MoveCommand}" />
+                    <MenuItem Header="_Size" Command="{Binding $parent[wm:ManagedWindow].SizeCommand}" />
                     <MenuItem Header="Mi_nimize" Command="{Binding $parent[wm:ManagedWindow].MinimizeCommand}" >
                       <MenuItem.Icon>
                         <ContentControl ContentTemplate="{StaticResource MinimizeIcon}" />
@@ -147,7 +149,8 @@
                         <ContentControl ContentTemplate="{StaticResource MaximizeIcon}" />
                       </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="_Close" Command="{Binding $parent[wm:ManagedWindow].CloseCommand}" >
+                    <Separator/>
+                    <MenuItem Header="_Close" Command="{Binding $parent[wm:ManagedWindow].CloseCommand}" InputGesture="Ctrl+F4" >
                       <MenuItem.Icon>
                         <ContentControl ContentTemplate="{StaticResource CloseIcon}" />
                       </MenuItem.Icon>

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
@@ -1427,10 +1427,10 @@ public class ManagedWindow : OverlayPopupHost
     StandardCursorType GetCursorForEdge(WindowEdge? edge)
         => edge switch
         {
-            WindowEdge.North => StandardCursorType.TopSide,
-            WindowEdge.South => StandardCursorType.BottomSide,
-            WindowEdge.West => StandardCursorType.LeftSide,
-            WindowEdge.East => StandardCursorType.RightSide,
+            WindowEdge.North => StandardCursorType.SizeNorthSouth,
+            WindowEdge.South => StandardCursorType.SizeNorthSouth,
+            WindowEdge.West => StandardCursorType.SizeWestEast,
+            WindowEdge.East => StandardCursorType.SizeWestEast,
             WindowEdge.NorthWest => StandardCursorType.TopLeftCorner,
             WindowEdge.NorthEast => StandardCursorType.TopRightCorner,
             WindowEdge.SouthWest => StandardCursorType.BottomLeftCorner,

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
@@ -214,56 +214,58 @@ public class ManagedWindow : OverlayPopupHost
             outputScheduler: AvaloniaScheduler.Instance);
 
         MaximizeCommand = ReactiveCommand.Create(() => { WindowState = WindowState.Maximized; },
-            canExecute: this.WhenAnyValue(win => win.WindowState).Select(state => state != WindowState.Maximized),
+            canExecute: this.WhenAnyValue(win => win.CanResize,win => win.WindowState,
+                (canResize, windowState) => canResize && windowState != WindowState.Maximized),
             outputScheduler: AvaloniaScheduler.Instance);
 
         MinimizeCommand = ReactiveCommand.Create(() => { WindowState = WindowState.Minimized; },
-            canExecute: this.WhenAnyValue(win => win.WindowState).Select(state => state != WindowState.Minimized),
+            canExecute: this.WhenAnyValue(win => win.CanResize, win => win.WindowState,
+                (canResize, windowState) => canResize && windowState != WindowState.Minimized),
             outputScheduler: AvaloniaScheduler.Instance);
 
         ShowSystemMenuCommand = ReactiveCommand.Create(() =>
-        {
-            _systemMenuItem.IsSubMenuOpen = true;
+            {
+                _systemMenuItem.IsSubMenuOpen = true;
 
-            //// Optionally, raise a synthetic KeyDown event for Alt or F10
-            //var keyEvent = new KeyEventArgs
-            //{
-            //    RoutedEvent = InputElement.KeyDownEvent,
-            //    Key = Key.F10,
-            //    KeyModifiers = KeyModifiers.None,
-            //    Source = _systemMenuItem
-            //};
-            //_systemMenuItem.RaiseEvent(keyEvent);
+                //// Optionally, raise a synthetic KeyDown event for Alt or F10
+                //var keyEvent = new KeyEventArgs
+                //{
+                //    RoutedEvent = InputElement.KeyDownEvent,
+                //    Key = Key.F10,
+                //    KeyModifiers = KeyModifiers.None,
+                //    Source = _systemMenuItem
+                //};
+                //_systemMenuItem.RaiseEvent(keyEvent);
 
-            // find first enabled child menu and set focus to it.
-            var firstEnabledChild = _systemMenuItem.Items
-                .OfType<MenuItem>()
-                .FirstOrDefault(mi => mi.IsEnabled);
-            firstEnabledChild?.Focus();
+                // find first enabled child menu and set focus to it.
+                var firstEnabledChild = _systemMenuItem.Items
+                    .OfType<MenuItem>()
+                    .FirstOrDefault(mi => mi.IsEnabled);
+                firstEnabledChild?.Focus();
 
-        }, outputScheduler: AvaloniaScheduler.Instance);
+            }, outputScheduler: AvaloniaScheduler.Instance);
 
         MoveCommand = ReactiveCommand.Create(() =>
-        {
-            _keyboardMoving = true;
-            _keyboardSizing = false;
-            PseudoClasses.Add(":dragging");
-        },
-        canExecute: this.WhenAnyValue(win => win.WindowState).Select(state => state == WindowState.Normal),
-        outputScheduler: AvaloniaScheduler.Instance);
+            {
+                _keyboardMoving = true;
+                _keyboardSizing = false;
+                PseudoClasses.Add(":dragging");
+            },
+            canExecute: this.WhenAnyValue(win => win.WindowState).Select(state => state == WindowState.Normal),
+            outputScheduler: AvaloniaScheduler.Instance);
 
         SizeCommand = ReactiveCommand.Create(() =>
-        {
-            if (CanResize)
             {
-                _keyboardSizing = true;
-                _keyboardMoving = false;
-                PseudoClasses.Add(":sizing");
-            }
-            _focus?.Focus();
-        },
-        canExecute: this.WhenAnyValue(win => win.WindowState).Select(state => state == WindowState.Normal),
-        outputScheduler: AvaloniaScheduler.Instance);
+                if (CanResize)
+                {
+                    _keyboardSizing = true;
+                    _keyboardMoving = false;
+                    PseudoClasses.Add(":sizing");
+                }
+                _focus?.Focus();
+            },
+            canExecute: this.WhenAnyValue(win => win.CanResize),
+            outputScheduler: AvaloniaScheduler.Instance);
     }
 
     public void PreviousWindow()

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
@@ -629,6 +629,7 @@ public class ManagedWindow : OverlayPopupHost
             _windowBorder.Margin = new Thickness(0);
             _windowBorder.BoxShadow = new BoxShadows();
         }
+        GetDefaultFocus()?.Focus();
     }
 
     protected virtual async void OnFullscreenWindow()
@@ -654,6 +655,7 @@ public class ManagedWindow : OverlayPopupHost
             _windowBorder.Margin = _normalMargin;
             _windowBorder.BoxShadow = _normalBoxShadow;
         }
+        GetDefaultFocus()?.Focus();
     }
 
     protected virtual async void OnMinimizeWindow()
@@ -671,6 +673,8 @@ public class ManagedWindow : OverlayPopupHost
         this.Position = _minimizedPosition;
         this.Width = double.NaN;
         this.Height = double.NaN;
+
+        _systemMenu?.Focus();
     }
 
     /// <summary>
@@ -1181,12 +1185,12 @@ public class ManagedWindow : OverlayPopupHost
             var cancelButton = buttons.FirstOrDefault(x => x.IsCancel);
             if (e.Key == Key.Escape && cancelButton != null)
             {
-                cancelButton.Command?.Execute(null);
+                cancelButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
                 e.Handled = true;
             }
             else if (e.Key == Key.Enter && defaultButton != null)
             {
-                defaultButton.Command?.Execute(null);
+                defaultButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
                 e.Handled = true;
             }
         }

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
@@ -25,6 +25,7 @@ namespace Iciclecreek.Avalonia.WindowManager;
 
 [TemplatePart(PART_TitleBar, typeof(Control))]
 [TemplatePart(PART_Title, typeof(TextBlock))]
+[TemplatePart(PART_SystemButton, typeof(Button))]
 [TemplatePart(PART_MinimizeButton, typeof(Button))]
 [TemplatePart(PART_MaximizeButton, typeof(Button))]
 [TemplatePart(PART_RestoreButton, typeof(Button))]
@@ -37,6 +38,7 @@ public class ManagedWindow : OverlayPopupHost
     public const string PART_ContentPresenter = "PART_ContentPresenter";
     public const string PART_TitleBar = "PART_TitleBar";
     public const string PART_Title = "PART_Title";
+    public const string PART_SystemButton= "PART_SystemButton";
     public const string PART_MinimizeButton = "PART_MinimizeButton";
     public const string PART_MaximizeButton = "PART_MaximizeButton";
     public const string PART_RestoreButton = "PART_RestoreButton";

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
@@ -1213,6 +1213,25 @@ public class ManagedWindow : OverlayPopupHost
                 return;
             }
         }
+        else if (e.Key == Key.F6)
+        {
+            if (e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            {
+                if (s_MRU == null)
+                    s_MRU = GetWindows().ToList();
+                PreviousWindow();
+                e.Handled = true;
+                return;
+            }
+            else 
+            {
+                if (s_MRU == null)
+                    s_MRU = GetWindows().ToList();
+                NextWindow();
+                e.Handled = true;
+                return;
+            }
+        }
         s_MRU = null;
     }
 

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
@@ -25,7 +25,6 @@ namespace Iciclecreek.Avalonia.WindowManager;
 
 [TemplatePart(PART_TitleBar, typeof(Control))]
 [TemplatePart(PART_Title, typeof(TextBlock))]
-[TemplatePart(PART_SystemButton, typeof(Button))]
 [TemplatePart(PART_MinimizeButton, typeof(Button))]
 [TemplatePart(PART_MaximizeButton, typeof(Button))]
 [TemplatePart(PART_RestoreButton, typeof(Button))]
@@ -38,7 +37,7 @@ public class ManagedWindow : OverlayPopupHost
     public const string PART_ContentPresenter = "PART_ContentPresenter";
     public const string PART_TitleBar = "PART_TitleBar";
     public const string PART_Title = "PART_Title";
-    public const string PART_SystemButton= "PART_SystemButton";
+    public const string PART_SystemMenu= "PART_SystemMenu";
     public const string PART_MinimizeButton = "PART_MinimizeButton";
     public const string PART_MaximizeButton = "PART_MaximizeButton";
     public const string PART_RestoreButton = "PART_RestoreButton";
@@ -1459,6 +1458,11 @@ public class ManagedWindow : OverlayPopupHost
         this.Close();
     }
 
+
+    private void OnSystemButtonClick(object? sender, RoutedEventArgs e)
+    {
+        throw new NotImplementedException();
+    }
 
     private void OnMinimizeClick(object? sender, RoutedEventArgs e)
     {

--- a/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
+++ b/source/Iciclecreek.Avalonia.WindowManager/ManagedWindow.axaml.cs
@@ -204,7 +204,7 @@ public class ManagedWindow : OverlayPopupHost
         : base(layer)
     {
         OverlayLayer = layer;
-        layer.ZIndex = 100000000;
+        //layer.ZIndex = 10000000;
         SetValue(KeyboardNavigation.TabNavigationProperty, KeyboardNavigationMode.Cycle);
 
         CloseCommand = ReactiveCommand.Create(() => Close(), outputScheduler: AvaloniaScheduler.Instance);
@@ -1281,18 +1281,24 @@ public class ManagedWindow : OverlayPopupHost
 
         if (e.Key == Key.Escape || e.Key == Key.Enter)
         {
-            var buttons = this.GetVisualDescendants().OfType<Button>().ToList();
-            var defaultButton = buttons.FirstOrDefault(x => x.IsDefault);
-            var cancelButton = buttons.FirstOrDefault(x => x.IsCancel);
-            if (e.Key == Key.Escape && cancelButton != null)
+            var focusManager = TopLevel.GetTopLevel(this)?.FocusManager;
+            var focusedElement = focusManager?.GetFocusedElement();
+            bool isMenuFocused = focusedElement is Menu || focusedElement is MenuItem;
+            if (!isMenuFocused)
             {
-                cancelButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
-                e.Handled = true;
-            }
-            else if (e.Key == Key.Enter && defaultButton != null)
-            {
-                defaultButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
-                e.Handled = true;
+                var buttons = this.GetVisualDescendants().OfType<Button>().ToList();
+                var defaultButton = buttons.FirstOrDefault(x => x.IsDefault);
+                var cancelButton = buttons.FirstOrDefault(x => x.IsCancel);
+                if (e.Key == Key.Escape && cancelButton != null)
+                {
+                    cancelButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                    e.Handled = true;
+                }
+                else if (e.Key == Key.Enter && defaultButton != null)
+                {
+                    defaultButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                    e.Handled = true;
+                }
             }
         }
         else if (e.Key == Key.Tab)
@@ -1303,6 +1309,7 @@ public class ManagedWindow : OverlayPopupHost
                     s_MRU = GetWindows().ToList();
                 PreviousWindow();
                 e.Handled = true;
+                // return because we don't want to reset the MRU 
                 return;
             }
             else if (e.KeyModifiers.HasFlag(KeyModifiers.Control))
@@ -1311,6 +1318,7 @@ public class ManagedWindow : OverlayPopupHost
                     s_MRU = GetWindows().ToList();
                 NextWindow();
                 e.Handled = true;
+                // return because we don't want to reset the MRU 
                 return;
             }
         }


### PR DESCRIPTION
The window manager supports hotkeys for common actions like closing a window, minimizing, maximizing, etc.
![winhotkeys](https://github.com/user-attachments/assets/2b2a3d0f-a894-4eab-b6c5-2d589bc78486)

|Hotkey | Action |
|--------|--------|
|Ctrl+F4 | Close the current window |
|Ctrl+Tab| Activate the next window |
|Ctrl+Shift+Tab | Activate the previous window |
|Alt+-| Show System menu (Restore/Move/Size/Maximize/Minimize/Close)|
|F6| Activate the next window |
|Shift+F6| Activate the previous window |

> NOTE: On windows consoles Ctrl+Tab and Ctrl+Shift+Tab are handled by the console window, so F6 and Shift+F6 should be used instead.
